### PR TITLE
Fixed the binary tree left and right nodes calculation

### DIFF
--- a/algorithms/sorting/heap_sort.py
+++ b/algorithms/sorting/heap_sort.py
@@ -19,8 +19,8 @@
 
 
 def max_heapify(seq, i, n):
-    l = i + 1
-    r = i + 2
+    l = 2 * i + 1
+    r = 2 * i + 2
 
     if l <= n and seq[l] > seq[i]:
         largest = l


### PR DESCRIPTION
The original code works somehow, but it is not logical.

Let's say a length-10 list A, index starts from 0. The left and right node of node `A[1]`(the 2nd node), should be `A[3]` and `A[4]` (they are 1_2+1 and 1_2+2), instead of `A[2]` and `A[3]` (i+1, 1+2).
