### PR TITLE
Missing tests - Adding two missing tests and re-ordering existing tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 /*.egg-info
 *.ropeproject/
 docs/_build
+.idea/*

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -2,324 +2,17 @@ from random import shuffle
 import unittest
 
 from algorithms.data_structures import (
-    stack,
+    binary_search_tree,
+    digraph,
     queue,
+    singly_linked_list,
+    stack,
+    undirected_graph,
     union_find,
     union_find_by_rank,
     union_find_with_path_compression,
-    digraph,
-    singly_linked_list,
-    undirected_graph,
-    binary_search_tree,
     lcp_array
 )
-
-
-class TestStack(unittest.TestCase):
-    """
-    Test Stack Implementation
-    """
-    def test_stack(self):
-        self.sta = stack.Stack()
-        self.sta.add(5)
-        self.sta.add(8)
-        self.sta.add(10)
-        self.sta.add(2)
-
-        self.assertEqual(self.sta.remove(), 2)
-        self.assertEqual(self.sta.is_empty(), False)
-        self.assertEqual(self.sta.size(), 3)
-
-
-class TestQueue(unittest.TestCase):
-    """
-    Test Queue Implementation
-    """
-    def test_queue(self):
-        self.que = queue.Queue()
-        self.que.add(1)
-        self.que.add(2)
-        self.que.add(8)
-        self.que.add(5)
-        self.que.add(6)
-
-        self.assertEqual(self.que.remove(), 1)
-        self.assertEqual(self.que.size(), 4)
-        self.assertEqual(self.que.remove(), 2)
-        self.assertEqual(self.que.remove(), 8)
-        self.assertEqual(self.que.remove(), 5)
-        self.assertEqual(self.que.remove(), 6)
-        self.assertEqual(self.que.is_empty(), True)
-
-
-class TestUnionFind(unittest.TestCase):
-    """
-    Test Union Find Implementation
-    """
-    def test_union_find(self):
-        self.uf = union_find.UnionFind(4)
-        self.uf.make_set(4)
-        self.uf.union(1, 0)
-        self.uf.union(3, 4)
-
-        self.assertEqual(self.uf.find(1), 0)
-        self.assertEqual(self.uf.find(3), 4)
-        self.assertEqual(self.uf.is_connected(0, 1), True)
-        self.assertEqual(self.uf.is_connected(3, 4), True)
-
-
-class TestUnionFindByRank(unittest.TestCase):
-    """
-    Test Union Find Implementation
-    """
-    def test_union_find_by_rank(self):
-        self.uf = union_find_by_rank.UnionFindByRank(6)
-        self.uf.make_set(6)
-        self.uf.union(1, 0)
-        self.uf.union(3, 4)
-        self.uf.union(2, 4)
-        self.uf.union(5, 2)
-        self.uf.union(6, 5)
-
-        self.assertEqual(self.uf.find(1), 1)
-        self.assertEqual(self.uf.find(3), 3)
-        # test tree is created by rank
-        self.uf.union(5, 0)
-        self.assertEqual(self.uf.find(2), 3)
-        self.assertEqual(self.uf.find(5), 3)
-        self.assertEqual(self.uf.find(6), 3)
-        self.assertEqual(self.uf.find(0), 3)
-
-        self.assertEqual(self.uf.is_connected(0, 1), True)
-        self.assertEqual(self.uf.is_connected(3, 4), True)
-        self.assertEqual(self.uf.is_connected(5, 3), True)
-
-
-class TestUnionFindWithPathCompression(unittest.TestCase):
-    """
-    Test Union Find Implementation
-    """
-    def test_union_find_with_path_compression(self):
-        self.uf = (
-            union_find_with_path_compression
-            .UnionFindWithPathCompression(5)
-        )
-        self.uf.make_set(5)
-        self.uf.union(0, 1)
-        self.uf.union(2, 3)
-        self.uf.union(1, 3)
-        self.uf.union(4, 5)
-        self.assertEqual(self.uf.find(1), 0)
-        self.assertEqual(self.uf.find(3), 0)
-        self.assertEqual(self.uf.parent(3), 2)
-        self.assertEqual(self.uf.parent(5), 4)
-        self.assertEqual(self.uf.is_connected(3, 5), False)
-        self.assertEqual(self.uf.is_connected(4, 5), True)
-        self.assertEqual(self.uf.is_connected(2, 3), True)
-        # test tree is created by path compression
-        self.uf.union(5, 3)
-        self.assertEqual(self.uf.parent(3), 0)
-
-        self.assertEqual(self.uf.is_connected(3, 5), True)
-
-
-class TestSinglyLinkedList(unittest.TestCase):
-    """
-    Test Singly Linked List Implementation
-    """
-
-    def test_singly_linked_list(self):
-        self.sl = singly_linked_list.SinglyLinkedList()
-        self.sl.add(10)
-        self.sl.add(5)
-        self.sl.add(30)
-        self.sl.remove(30)
-
-        self.assertEqual(self.sl.size, 2)
-        self.assertEqual(self.sl.search(30), False)
-        self.assertEqual(self.sl.search(5), True)
-        self.assertEqual(self.sl.search(10), True)
-        self.assertEqual(self.sl.remove(5), True)
-        self.assertEqual(self.sl.remove(10), True)
-        self.assertEqual(self.sl.size, 0)
-
-
-class TestUndirectedGraph(unittest.TestCase):
-    """
-    Test Undirected Graph Implementation
-    """
-    def test_undirected_graph(self):
-
-        # init
-        self.ug0 = undirected_graph.Undirected_Graph()
-        self.ug1 = undirected_graph.Undirected_Graph()
-        self.ug2 = undirected_graph.Undirected_Graph()
-        self.ug3 = undirected_graph.Undirected_Graph()
-
-        # populating
-        self.ug1.add_edge(1, 2)
-
-        self.ug2.add_edge(1, 2)
-        self.ug2.add_edge(1, 2)
-
-        self.ug3.add_edge(1, 2)
-        self.ug3.add_edge(1, 2)
-        self.ug3.add_edge(3, 1)
-
-        # test adj
-        self.assertTrue(2 in self.ug1.adj(1))
-        self.assertEqual(len(self.ug1.adj(1)), 1)
-        self.assertTrue(1 in self.ug1.adj(2))
-        self.assertEqual(len(self.ug1.adj(1)), 1)
-
-        self.assertTrue(2 in self.ug2.adj(1))
-        self.assertEqual(len(self.ug2.adj(1)), 2)
-        self.assertTrue(1 in self.ug2.adj(2))
-        self.assertEqual(len(self.ug2.adj(1)), 2)
-
-        self.assertTrue(2 in self.ug3.adj(1))
-        self.assertTrue(3 in self.ug3.adj(1))
-        self.assertEqual(len(self.ug3.adj(1)), 3)
-        self.assertTrue(1 in self.ug3.adj(2))
-        self.assertEqual(len(self.ug3.adj(2)), 2)
-        self.assertTrue(1 in self.ug3.adj(3))
-        self.assertEqual(len(self.ug3.adj(3)), 1)
-
-        # test degree
-        self.assertEqual(self.ug1.degree(1), 1)
-        self.assertEqual(self.ug1.degree(2), 1)
-        self.assertEqual(self.ug2.degree(1), 2)
-        self.assertEqual(self.ug2.degree(2), 2)
-        self.assertEqual(self.ug3.degree(1), 3)
-        self.assertEqual(self.ug3.degree(2), 2)
-        self.assertEqual(self.ug3.degree(3), 1)
-
-        # test vertices
-        self.assertEqual(list(self.ug0.vertices()), [])
-        self.assertEqual(len(self.ug0.vertices()), 0)
-
-        self.assertTrue(1 in self.ug1.vertices())
-        self.assertTrue(2 in self.ug1.vertices())
-        self.assertEqual(len(self.ug1.vertices()), 2)
-
-        self.assertTrue(1 in self.ug2.vertices())
-        self.assertTrue(2 in self.ug2.vertices())
-        self.assertEqual(len(self.ug2.vertices()), 2)
-
-        self.assertTrue(1 in self.ug3.vertices())
-        self.assertTrue(2 in self.ug3.vertices())
-        self.assertTrue(3 in self.ug3.vertices())
-        self.assertEqual(len(self.ug3.vertices()), 3)
-
-        # test vertex_count
-        self.assertEqual(self.ug0.vertex_count(), 0)
-        self.assertEqual(self.ug1.vertex_count(), 2)
-        self.assertEqual(self.ug2.vertex_count(), 2)
-        self.assertEqual(self.ug3.vertex_count(), 3)
-
-        # test edge_count
-        self.assertEqual(self.ug0.edge_count(), 0)
-        self.assertEqual(self.ug1.edge_count(), 1)
-        self.assertEqual(self.ug2.edge_count(), 2)
-        self.assertEqual(self.ug3.edge_count(), 3)
-
-
-class TestDirectedGraph(unittest.TestCase):
-    """
-    Test Undirected Graph Implementation
-    """
-    def test_directed_graph(self):
-
-        # init
-        self.dg0 = digraph.Digraph()
-        self.dg1 = digraph.Digraph()
-        self.dg2 = digraph.Digraph()
-        self.dg3 = digraph.Digraph()
-
-        # populating
-        self.dg1.add_edge(1, 2)
-
-        self.dg1_rev = self.dg1.reverse()  # reverse
-
-        self.dg2.add_edge(1, 2)
-        self.dg2.add_edge(1, 2)
-
-        self.dg3.add_edge(1, 2)
-        self.dg3.add_edge(1, 2)
-        self.dg3.add_edge(3, 1)
-
-        # test adj
-        self.assertTrue(2 in self.dg1.adj(1))
-        self.assertEqual(len(self.dg1.adj(1)), 1)
-        self.assertTrue(1 not in self.dg1.adj(2))
-        self.assertEqual(len(self.dg1.adj(2)), 0)
-
-        self.assertTrue(1 in self.dg1_rev.adj(2))
-        self.assertEqual(len(self.dg1_rev.adj(2)), 1)
-        self.assertTrue(2 not in self.dg1_rev.adj(1))
-        self.assertEqual(len(self.dg1_rev.adj(1)), 0)
-
-        self.assertTrue(2 in self.dg2.adj(1))
-        self.assertEqual(len(self.dg2.adj(1)), 2)
-        self.assertTrue(1 not in self.dg2.adj(2))
-        self.assertEqual(len(self.dg2.adj(2)), 0)
-
-        self.assertTrue(2 in self.dg3.adj(1))
-        self.assertTrue(1 in self.dg3.adj(3))
-        self.assertEqual(len(self.dg3.adj(1)), 2)
-        self.assertTrue(1 not in self.dg3.adj(2))
-        self.assertEqual(len(self.dg3.adj(2)), 0)
-        self.assertTrue(3 not in self.dg3.adj(1))
-        self.assertEqual(len(self.dg3.adj(3)), 1)
-
-        # test degree
-        self.assertEqual(self.dg1.outdegree(1), 1)
-        self.assertEqual(self.dg1.outdegree(2), 0)
-
-        self.assertEqual(self.dg1_rev.outdegree(2), 1)
-        self.assertEqual(self.dg1_rev.outdegree(1), 0)
-
-        self.assertEqual(self.dg2.outdegree(1), 2)
-        self.assertEqual(self.dg2.outdegree(2), 0)
-
-        self.assertEqual(self.dg3.outdegree(1), 2)
-        self.assertEqual(self.dg3.outdegree(2), 0)
-        self.assertEqual(self.dg3.outdegree(3), 1)
-
-        # test vertices
-        self.assertEqual(list(self.dg0.vertices()), [])
-        self.assertEqual(len(self.dg0.vertices()), 0)
-
-        self.assertTrue(1 in self.dg1.vertices())
-        self.assertTrue(2 in self.dg1.vertices())
-        self.assertEqual(len(self.dg1.vertices()), 2)
-
-        self.assertTrue(2 in self.dg1_rev.vertices())
-        self.assertTrue(1 in self.dg1_rev.vertices())
-        self.assertEqual(len(self.dg1_rev.vertices()), 2)
-
-        self.assertTrue(1 in self.dg2.vertices())
-        self.assertTrue(2 in self.dg2.vertices())
-        self.assertEqual(len(self.dg2.vertices()), 2)
-
-        self.assertTrue(1 in self.dg3.vertices())
-        self.assertTrue(2 in self.dg3.vertices())
-        self.assertTrue(3 in self.dg3.vertices())
-        self.assertEqual(len(self.dg3.vertices()), 3)
-
-        # test vertex_count
-        self.assertEqual(self.dg0.vertex_count(), 0)
-        self.assertEqual(self.dg1.vertex_count(), 2)
-        self.assertEqual(self.dg1_rev.vertex_count(), 2)
-        self.assertEqual(self.dg2.vertex_count(), 2)
-        self.assertEqual(self.dg3.vertex_count(), 3)
-
-        # test edge_count
-        self.assertEqual(self.dg0.edge_count(), 0)
-        self.assertEqual(self.dg1.edge_count(), 1)
-        self.assertEqual(self.dg1_rev.edge_count(), 1)
-        self.assertEqual(self.dg2.edge_count(), 2)
-        self.assertEqual(self.dg3.edge_count(), 3)
 
 
 class TestBinarySearchTree(unittest.TestCase):
@@ -672,6 +365,314 @@ class TestBinarySearchTree(unittest.TestCase):
             self.bst.keys(),
             ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
         )
+
+
+class TestDirectedGraph(unittest.TestCase):
+    """
+    Test Undirected Graph Implementation
+    """
+    def test_directed_graph(self):
+
+        # init
+        self.dg0 = digraph.Digraph()
+        self.dg1 = digraph.Digraph()
+        self.dg2 = digraph.Digraph()
+        self.dg3 = digraph.Digraph()
+
+        # populating
+        self.dg1.add_edge(1, 2)
+
+        self.dg1_rev = self.dg1.reverse()  # reverse
+
+        self.dg2.add_edge(1, 2)
+        self.dg2.add_edge(1, 2)
+
+        self.dg3.add_edge(1, 2)
+        self.dg3.add_edge(1, 2)
+        self.dg3.add_edge(3, 1)
+
+        # test adj
+        self.assertTrue(2 in self.dg1.adj(1))
+        self.assertEqual(len(self.dg1.adj(1)), 1)
+        self.assertTrue(1 not in self.dg1.adj(2))
+        self.assertEqual(len(self.dg1.adj(2)), 0)
+
+        self.assertTrue(1 in self.dg1_rev.adj(2))
+        self.assertEqual(len(self.dg1_rev.adj(2)), 1)
+        self.assertTrue(2 not in self.dg1_rev.adj(1))
+        self.assertEqual(len(self.dg1_rev.adj(1)), 0)
+
+        self.assertTrue(2 in self.dg2.adj(1))
+        self.assertEqual(len(self.dg2.adj(1)), 2)
+        self.assertTrue(1 not in self.dg2.adj(2))
+        self.assertEqual(len(self.dg2.adj(2)), 0)
+
+        self.assertTrue(2 in self.dg3.adj(1))
+        self.assertTrue(1 in self.dg3.adj(3))
+        self.assertEqual(len(self.dg3.adj(1)), 2)
+        self.assertTrue(1 not in self.dg3.adj(2))
+        self.assertEqual(len(self.dg3.adj(2)), 0)
+        self.assertTrue(3 not in self.dg3.adj(1))
+        self.assertEqual(len(self.dg3.adj(3)), 1)
+
+        # test degree
+        self.assertEqual(self.dg1.outdegree(1), 1)
+        self.assertEqual(self.dg1.outdegree(2), 0)
+
+        self.assertEqual(self.dg1_rev.outdegree(2), 1)
+        self.assertEqual(self.dg1_rev.outdegree(1), 0)
+
+        self.assertEqual(self.dg2.outdegree(1), 2)
+        self.assertEqual(self.dg2.outdegree(2), 0)
+
+        self.assertEqual(self.dg3.outdegree(1), 2)
+        self.assertEqual(self.dg3.outdegree(2), 0)
+        self.assertEqual(self.dg3.outdegree(3), 1)
+
+        # test vertices
+        self.assertEqual(list(self.dg0.vertices()), [])
+        self.assertEqual(len(self.dg0.vertices()), 0)
+
+        self.assertTrue(1 in self.dg1.vertices())
+        self.assertTrue(2 in self.dg1.vertices())
+        self.assertEqual(len(self.dg1.vertices()), 2)
+
+        self.assertTrue(2 in self.dg1_rev.vertices())
+        self.assertTrue(1 in self.dg1_rev.vertices())
+        self.assertEqual(len(self.dg1_rev.vertices()), 2)
+
+        self.assertTrue(1 in self.dg2.vertices())
+        self.assertTrue(2 in self.dg2.vertices())
+        self.assertEqual(len(self.dg2.vertices()), 2)
+
+        self.assertTrue(1 in self.dg3.vertices())
+        self.assertTrue(2 in self.dg3.vertices())
+        self.assertTrue(3 in self.dg3.vertices())
+        self.assertEqual(len(self.dg3.vertices()), 3)
+
+        # test vertex_count
+        self.assertEqual(self.dg0.vertex_count(), 0)
+        self.assertEqual(self.dg1.vertex_count(), 2)
+        self.assertEqual(self.dg1_rev.vertex_count(), 2)
+        self.assertEqual(self.dg2.vertex_count(), 2)
+        self.assertEqual(self.dg3.vertex_count(), 3)
+
+        # test edge_count
+        self.assertEqual(self.dg0.edge_count(), 0)
+        self.assertEqual(self.dg1.edge_count(), 1)
+        self.assertEqual(self.dg1_rev.edge_count(), 1)
+        self.assertEqual(self.dg2.edge_count(), 2)
+        self.assertEqual(self.dg3.edge_count(), 3)
+
+
+class TestQueue(unittest.TestCase):
+    """
+    Test Queue Implementation
+    """
+    def test_queue(self):
+        self.que = queue.Queue()
+        self.que.add(1)
+        self.que.add(2)
+        self.que.add(8)
+        self.que.add(5)
+        self.que.add(6)
+
+        self.assertEqual(self.que.remove(), 1)
+        self.assertEqual(self.que.size(), 4)
+        self.assertEqual(self.que.remove(), 2)
+        self.assertEqual(self.que.remove(), 8)
+        self.assertEqual(self.que.remove(), 5)
+        self.assertEqual(self.que.remove(), 6)
+        self.assertEqual(self.que.is_empty(), True)
+
+
+class TestSinglyLinkedList(unittest.TestCase):
+    """
+    Test Singly Linked List Implementation
+    """
+
+    def test_singly_linked_list(self):
+        self.sl = singly_linked_list.SinglyLinkedList()
+        self.sl.add(10)
+        self.sl.add(5)
+        self.sl.add(30)
+        self.sl.remove(30)
+
+        self.assertEqual(self.sl.size, 2)
+        self.assertEqual(self.sl.search(30), False)
+        self.assertEqual(self.sl.search(5), True)
+        self.assertEqual(self.sl.search(10), True)
+        self.assertEqual(self.sl.remove(5), True)
+        self.assertEqual(self.sl.remove(10), True)
+        self.assertEqual(self.sl.size, 0)
+
+
+class TestStack(unittest.TestCase):
+    """
+    Test Stack Implementation
+    """
+    def test_stack(self):
+        self.sta = stack.Stack()
+        self.sta.add(5)
+        self.sta.add(8)
+        self.sta.add(10)
+        self.sta.add(2)
+
+        self.assertEqual(self.sta.remove(), 2)
+        self.assertEqual(self.sta.is_empty(), False)
+        self.assertEqual(self.sta.size(), 3)
+
+
+class TestUndirectedGraph(unittest.TestCase):
+    """
+    Test Undirected Graph Implementation
+    """
+    def test_undirected_graph(self):
+
+        # init
+        self.ug0 = undirected_graph.Undirected_Graph()
+        self.ug1 = undirected_graph.Undirected_Graph()
+        self.ug2 = undirected_graph.Undirected_Graph()
+        self.ug3 = undirected_graph.Undirected_Graph()
+
+        # populating
+        self.ug1.add_edge(1, 2)
+
+        self.ug2.add_edge(1, 2)
+        self.ug2.add_edge(1, 2)
+
+        self.ug3.add_edge(1, 2)
+        self.ug3.add_edge(1, 2)
+        self.ug3.add_edge(3, 1)
+
+        # test adj
+        self.assertTrue(2 in self.ug1.adj(1))
+        self.assertEqual(len(self.ug1.adj(1)), 1)
+        self.assertTrue(1 in self.ug1.adj(2))
+        self.assertEqual(len(self.ug1.adj(1)), 1)
+
+        self.assertTrue(2 in self.ug2.adj(1))
+        self.assertEqual(len(self.ug2.adj(1)), 2)
+        self.assertTrue(1 in self.ug2.adj(2))
+        self.assertEqual(len(self.ug2.adj(1)), 2)
+
+        self.assertTrue(2 in self.ug3.adj(1))
+        self.assertTrue(3 in self.ug3.adj(1))
+        self.assertEqual(len(self.ug3.adj(1)), 3)
+        self.assertTrue(1 in self.ug3.adj(2))
+        self.assertEqual(len(self.ug3.adj(2)), 2)
+        self.assertTrue(1 in self.ug3.adj(3))
+        self.assertEqual(len(self.ug3.adj(3)), 1)
+
+        # test degree
+        self.assertEqual(self.ug1.degree(1), 1)
+        self.assertEqual(self.ug1.degree(2), 1)
+        self.assertEqual(self.ug2.degree(1), 2)
+        self.assertEqual(self.ug2.degree(2), 2)
+        self.assertEqual(self.ug3.degree(1), 3)
+        self.assertEqual(self.ug3.degree(2), 2)
+        self.assertEqual(self.ug3.degree(3), 1)
+
+        # test vertices
+        self.assertEqual(list(self.ug0.vertices()), [])
+        self.assertEqual(len(self.ug0.vertices()), 0)
+
+        self.assertTrue(1 in self.ug1.vertices())
+        self.assertTrue(2 in self.ug1.vertices())
+        self.assertEqual(len(self.ug1.vertices()), 2)
+
+        self.assertTrue(1 in self.ug2.vertices())
+        self.assertTrue(2 in self.ug2.vertices())
+        self.assertEqual(len(self.ug2.vertices()), 2)
+
+        self.assertTrue(1 in self.ug3.vertices())
+        self.assertTrue(2 in self.ug3.vertices())
+        self.assertTrue(3 in self.ug3.vertices())
+        self.assertEqual(len(self.ug3.vertices()), 3)
+
+        # test vertex_count
+        self.assertEqual(self.ug0.vertex_count(), 0)
+        self.assertEqual(self.ug1.vertex_count(), 2)
+        self.assertEqual(self.ug2.vertex_count(), 2)
+        self.assertEqual(self.ug3.vertex_count(), 3)
+
+        # test edge_count
+        self.assertEqual(self.ug0.edge_count(), 0)
+        self.assertEqual(self.ug1.edge_count(), 1)
+        self.assertEqual(self.ug2.edge_count(), 2)
+        self.assertEqual(self.ug3.edge_count(), 3)
+
+
+class TestUnionFind(unittest.TestCase):
+    """
+    Test Union Find Implementation
+    """
+    def test_union_find(self):
+        self.uf = union_find.UnionFind(4)
+        self.uf.make_set(4)
+        self.uf.union(1, 0)
+        self.uf.union(3, 4)
+
+        self.assertEqual(self.uf.find(1), 0)
+        self.assertEqual(self.uf.find(3), 4)
+        self.assertEqual(self.uf.is_connected(0, 1), True)
+        self.assertEqual(self.uf.is_connected(3, 4), True)
+
+
+class TestUnionFindByRank(unittest.TestCase):
+    """
+    Test Union Find Implementation
+    """
+    def test_union_find_by_rank(self):
+        self.uf = union_find_by_rank.UnionFindByRank(6)
+        self.uf.make_set(6)
+        self.uf.union(1, 0)
+        self.uf.union(3, 4)
+        self.uf.union(2, 4)
+        self.uf.union(5, 2)
+        self.uf.union(6, 5)
+
+        self.assertEqual(self.uf.find(1), 1)
+        self.assertEqual(self.uf.find(3), 3)
+        # test tree is created by rank
+        self.uf.union(5, 0)
+        self.assertEqual(self.uf.find(2), 3)
+        self.assertEqual(self.uf.find(5), 3)
+        self.assertEqual(self.uf.find(6), 3)
+        self.assertEqual(self.uf.find(0), 3)
+
+        self.assertEqual(self.uf.is_connected(0, 1), True)
+        self.assertEqual(self.uf.is_connected(3, 4), True)
+        self.assertEqual(self.uf.is_connected(5, 3), True)
+
+
+class TestUnionFindWithPathCompression(unittest.TestCase):
+    """
+    Test Union Find Implementation
+    """
+    def test_union_find_with_path_compression(self):
+        self.uf = (
+            union_find_with_path_compression
+            .UnionFindWithPathCompression(5)
+        )
+
+        self.uf.make_set(5)
+        self.uf.union(0, 1)
+        self.uf.union(2, 3)
+        self.uf.union(1, 3)
+        self.uf.union(4, 5)
+        self.assertEqual(self.uf.find(1), 0)
+        self.assertEqual(self.uf.find(3), 0)
+        self.assertEqual(self.uf.parent(3), 2)
+        self.assertEqual(self.uf.parent(5), 4)
+        self.assertEqual(self.uf.is_connected(3, 5), False)
+        self.assertEqual(self.uf.is_connected(4, 5), True)
+        self.assertEqual(self.uf.is_connected(2, 3), True)
+        # test tree is created by path compression
+        self.uf.union(5, 3)
+        self.assertEqual(self.uf.parent(3), 0)
+
+        self.assertEqual(self.uf.is_connected(3, 5), True)
 
 
 class TestLCPSuffixArrays(unittest.TestCase):

--- a/tests/test_factorization.py
+++ b/tests/test_factorization.py
@@ -6,6 +6,17 @@ from algorithms.factorization.trial_division import trial_division
 from algorithms.factorization.fermat import fermat
 
 
+class TestFermat(unittest.TestCase):
+
+    def test_fermat(self):
+        x = random.randint(1, 100000000)
+        factors = fermat(x)
+        res = 1
+        for i in factors:
+            res *= i
+        self.assertEqual(x, res)
+
+
 class TestPollardRho(unittest.TestCase):
 
     def test_pollard_rho(self):
@@ -22,17 +33,6 @@ class TestTrialDivision(unittest.TestCase):
     def test_trial_division(self):
         x = random.randint(0, 10000000000)
         factors = trial_division(x)
-        res = 1
-        for i in factors:
-            res *= i
-        self.assertEqual(x, res)
-
-
-class TestFermat(unittest.TestCase):
-
-    def test_fermat(self):
-        x = random.randint(1, 100000000)
-        factors = fermat(x)
         res = 1
         for i in factors:
             res *= i

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,11 +1,28 @@
 import unittest
 
+from algorithms.math.approx_cdf import cdf
 from algorithms.math.extended_gcd import extended_gcd
 from algorithms.math.lcm import lcm
-from algorithms.math.sieve_eratosthenes import eratosthenes
+from algorithms.math.primality_test import is_prime
 from algorithms.math.sieve_atkin import atkin
+from algorithms.math.sieve_eratosthenes import eratosthenes
 from algorithms.math.std_normal_pdf import pdf
-from algorithms.math.approx_cdf import cdf
+
+
+class TestApproxCdf(unittest.TestCase):
+
+    def test_cdf(self):
+        # Calculate cumulative distribution function for x=1
+        a = cdf(1)
+        self.assertAlmostEqual(a, 0.841344746068543)
+
+        # Calculate cumulative distribution function x=0
+        a = cdf(0)
+        self.assertAlmostEqual(a, 0.5)
+
+        # Calculate cumulative distribution function for x=(-1)
+        a = cdf(-1)
+        self.assertAlmostEqual(a, 0.15865525393145702)
 
 
 class TestExtendedGCD(unittest.TestCase):
@@ -43,25 +60,15 @@ class TestLCM(unittest.TestCase):
         self.assertEqual(r, r2)
 
 
-class TestSieveOfEratosthenes(unittest.TestCase):
-
-    def test_eratosthenes(self):
-        rv1 = eratosthenes(-10)
-        rv2 = eratosthenes(10)
-        rv3 = eratosthenes(100, 5)
-        rv4 = eratosthenes(100, -10)
-        self.assertEqual(rv1, [])
-        self.assertEqual(rv2, [2, 3, 5, 7])
-        self.assertEqual(
-            rv3,
-            [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61,
-             67, 71, 73, 79, 83, 89, 97]
-        )
-        self.assertEqual(
-            rv4,
-            [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59,
-             61, 67, 71, 73, 79, 83, 89, 97]
-        )
+class TestPrimalityTest(unittest.TestCase):
+    def test_is_prime(self):
+        self.assertIs(is_prime(3), True)
+        self.assertIs(is_prime(15), False)
+        self.assertIs(is_prime(20), False)
+        self.assertIs(is_prime(37), True)
+        self.assertIs(is_prime(63), False)
+        self.assertIs(is_prime(87), False)
+        self.assertIs(is_prime(103), True)
 
 
 class TestSieveOfAtkin(unittest.TestCase):
@@ -96,6 +103,27 @@ class TestSieveOfAtkin(unittest.TestCase):
         self.assertEqual(rv4, [])
 
 
+class TestSieveOfEratosthenes(unittest.TestCase):
+
+    def test_eratosthenes(self):
+        rv1 = eratosthenes(-10)
+        rv2 = eratosthenes(10)
+        rv3 = eratosthenes(100, 5)
+        rv4 = eratosthenes(100, -10)
+        self.assertEqual(rv1, [])
+        self.assertEqual(rv2, [2, 3, 5, 7])
+        self.assertEqual(
+            rv3,
+            [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61,
+             67, 71, 73, 79, 83, 89, 97]
+        )
+        self.assertEqual(
+            rv4,
+            [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59,
+             61, 67, 71, 73, 79, 83, 89, 97]
+        )
+
+
 class TestStdNormPDF(unittest.TestCase):
 
     def test_pdf(self):
@@ -110,19 +138,3 @@ class TestStdNormPDF(unittest.TestCase):
         # Calculate standard normal pdf for x=13, mean=10, std_dev=1
         a = pdf(x=13, mean=10, std_dev=1)
         self.assertAlmostEqual(a, 0.004431848411938008)
-
-
-class TestApproxCdf(unittest.TestCase):
-
-    def test_cdf(self):
-        # Calculate cumulative distribution function for x=1
-        a = cdf(1)
-        self.assertAlmostEqual(a, 0.841344746068543)
-
-        # Calculate cumulative distribution function x=0
-        a = cdf(0)
-        self.assertAlmostEqual(a, 0.5)
-
-        # Calculate cumulative distribution function for x=(-1)
-        a = cdf(-1)
-        self.assertAlmostEqual(a, 0.15865525393145702)

--- a/tests/test_searching.py
+++ b/tests/test_searching.py
@@ -3,11 +3,11 @@ import unittest
 
 from algorithms.searching import (
     binary_search,
-    kmp_search,
-    rabinkarp_search,
     bmh_search,
+    breadth_first_search,
     depth_first_search,
-    breadth_first_search
+    kmp_search,
+    rabinkarp_search
 )
 
 
@@ -41,32 +41,6 @@ class TestBinarySearch(unittest.TestCase):
         self.assertIs(rv5, 4)
 
 
-class TestKMPSearch(unittest.TestCase):
-    """
-    Tests KMP search on string "ABCDE FG ABCDEABCDEF"
-    """
-
-    def test_kmpsearch(self):
-        self.string = "ABCDE FG ABCDEABCDEF"
-        rv1 = kmp_search.search(self.string, "ABCDEA")
-        rv2 = kmp_search.search(self.string, "ABCDER")
-        self.assertIs(rv1[0], 9)
-        self.assertFalse(rv2)
-
-
-class TestRabinKarpSearch(unittest.TestCase):
-    """
-    Tests Rabin-Karp search on string "ABCDEFGHIJKLMNOP"
-    """
-
-    def test_rabinkarpsearch(self):
-        self.string = "ABCDEFGHIJKLMNOP"
-        rv1 = rabinkarp_search.search(self.string, "MNOP")
-        rv2 = rabinkarp_search.search(self.string, "BCA")
-        self.assertIs(rv1[0], 12)
-        self.assertFalse(rv2)
-
-
 class TestBMHSearch(unittest.TestCase):
     """
     Tests BMH search on string "ABCDE FG ABCDEABCDEF"
@@ -78,6 +52,38 @@ class TestBMHSearch(unittest.TestCase):
         rv2 = bmh_search.search(self.string, "ABCDER")
         self.assertIs(rv1[0], 9)
         self.assertFalse(rv2)
+
+
+class TestBreadthFirstSearch(unittest.TestCase):
+    """
+    Tests DFS on a graph represented by a adjacency list
+    """
+    def test_bfs(self):
+        self.graph = {
+            'A': {'B', 'C'},
+            'B': {'A', 'D', 'E'},
+            'C': {'A', 'F'},
+            'D': {'B'},
+            'E': {'B', 'F'},
+            'F': {'C', 'E'}
+        }
+        rv1 = breadth_first_search.bfs(self.graph, 'A')
+        self.assertEqual(rv1, {'C', 'A', 'B', 'D', 'F', 'E'})
+        self.graph = {
+            'A': {'B', 'C', 'E'},
+            'B': {'A', 'D', 'F'},
+            'C': {'A', 'G'},
+            'D': {'B'},
+            'F': {'B'},
+            'E': {'A'},
+            'G': {'C'}
+        }
+        rv1 = breadth_first_search.bfs(self.graph, "A")
+        rv2 = breadth_first_search.bfs(self.graph, "G")
+        rv1e = breadth_first_search.bfs(self.graph, "Z")
+        self.assertEqual(rv1, {'A', 'B', 'D', 'F', 'C', 'G', 'E'})
+        self.assertEqual(rv2, {'G', 'C', 'A', 'B', 'D', 'F', 'E'})
+        self.assertEqual(rv1e, None)
 
 
 class TestDepthFirstSearch(unittest.TestCase):
@@ -158,33 +164,27 @@ class TestDepthFirstSearch(unittest.TestCase):
         self.assertEqual(rv3e, None)
 
 
-class TestBreadthFirstSearch(unittest.TestCase):
+class TestKMPSearch(unittest.TestCase):
     """
-    Tests DFS on a graph represented by a adjacency list
+    Tests KMP search on string "ABCDE FG ABCDEABCDEF"
     """
-    def test_bfs(self):
-        self.graph = {
-            'A': set(['B', 'C']),
-            'B': set(['A', 'D', 'E']),
-            'C': set(['A', 'F']),
-            'D': set(['B']),
-            'E': set(['B', 'F']),
-            'F': set(['C', 'E'])
-        }
-        rv1 = breadth_first_search.bfs(self.graph, 'A')
-        self.assertEqual(rv1, {'C', 'A', 'B', 'D', 'F', 'E'})
-        self.graph = {
-            'A': set(['B', 'C', 'E']),
-            'B': set(['A', 'D', 'F']),
-            'C': set(['A', 'G']),
-            'D': set(['B']),
-            'F': set(['B']),
-            'E': set(['A']),
-            'G': set(['C'])
-        }
-        rv1 = breadth_first_search.bfs(self.graph, "A")
-        rv2 = breadth_first_search.bfs(self.graph, "G")
-        rv1e = breadth_first_search.bfs(self.graph, "Z")
-        self.assertEqual(rv1, set(['A', 'B', 'D', 'F', 'C', 'G', 'E']))
-        self.assertEqual(rv2, set(['G', 'C', 'A', 'B', 'D', 'F', 'E']))
-        self.assertEqual(rv1e, None)
+
+    def test_kmpsearch(self):
+        self.string = "ABCDE FG ABCDEABCDEF"
+        rv1 = kmp_search.search(self.string, "ABCDEA")
+        rv2 = kmp_search.search(self.string, "ABCDER")
+        self.assertIs(rv1[0], 9)
+        self.assertFalse(rv2)
+
+
+class TestRabinKarpSearch(unittest.TestCase):
+    """
+    Tests Rabin-Karp search on string "ABCDEFGHIJKLMNOP"
+    """
+
+    def test_rabinkarpsearch(self):
+        self.string = "ABCDEFGHIJKLMNOP"
+        rv1 = rabinkarp_search.search(self.string, "MNOP")
+        rv2 = rabinkarp_search.search(self.string, "BCA")
+        self.assertIs(rv1[0], 12)
+        self.assertFalse(rv2)

--- a/tests/test_shuffling.py
+++ b/tests/test_shuffling.py
@@ -22,6 +22,6 @@ class TestKnuthShuffle(ShufflingAlgorithmTestCase):
 
         for i in self.sorted:
             if i == self.shuffle[i]:
-                self.not_shuffled = self.not_shuffled + 1
+                self.not_shuffled += 1
 
         self.assertGreater(5, self.not_shuffled)

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -2,17 +2,18 @@ import random
 import unittest
 
 from algorithms.sorting import (
+    bogo_sort,
     bubble_sort,
-    selection_sort,
+    cocktail_sort,
+    comb_sort,
+    gnome_sort,
+    heap_sort,
     insertion_sort,
     merge_sort,
     quick_sort,
-    heap_sort,
-    shell_sort,
-    comb_sort,
-    cocktail_sort,
     quick_sort_in_place,
-    gnome_sort,
+    selection_sort,
+    shell_sort,
     strand_sort,
 )
 
@@ -28,6 +29,16 @@ class SortingAlgorithmTestCase(unittest.TestCase):
         self.correct = list(range(10))
 
 
+class TestBogoSort(SortingAlgorithmTestCase):
+    """
+    Tests Bogo sort on a small range from 0-9
+    """
+
+    def test_bogosort(self):
+        self.output = bogo_sort.sort(self.input)
+        self.assertEqual(self.correct, self.input)
+
+
 class TestBubbleSort(SortingAlgorithmTestCase):
     """
     Tests Bubble sort on a small range from 0-9
@@ -38,13 +49,43 @@ class TestBubbleSort(SortingAlgorithmTestCase):
         self.assertEqual(self.correct, self.output)
 
 
-class TestSelectionSort(SortingAlgorithmTestCase):
+class TestCocktailSort(SortingAlgorithmTestCase):
     """
-    Tests Selection sort on a small range from 0-9
+    Tests Cocktail sort on a small range from 0-9
     """
 
-    def test_selectionsort(self):
-        self.output = selection_sort.sort(self.input)
+    def test_cocktailsort(self):
+        self.output = cocktail_sort.sort(self.input)
+        self.assertEqual(self.correct, self.output)
+
+
+class TestCombSort(SortingAlgorithmTestCase):
+    """
+    Tests Comb sort on a small range from 0-9
+    """
+
+    def test_combsort(self):
+        self.output = comb_sort.sort(self.input)
+        self.assertEqual(self.correct, self.output)
+
+
+class TestGnomeSort(SortingAlgorithmTestCase):
+    """
+    Tests Gnome sort on a small range from 0-9
+    """
+
+    def test_gnomesort(self):
+        self.output = gnome_sort.sort(self.input)
+        self.assertEqual(self.correct, self.output)
+
+
+class TestHeapSort(SortingAlgorithmTestCase):
+    """
+    Test Heap sort on a small range from 0-9
+    """
+
+    def test_heapsort(self):
+        self.output = heap_sort.sort(self.input)
         self.assertEqual(self.correct, self.output)
 
 
@@ -53,7 +94,7 @@ class TestInsertionSort(SortingAlgorithmTestCase):
     Tests Insertion sort on a small range from 0-9
     """
 
-    def test_selectionsort(self):
+    def test_insertionsort(self):
         self.output = insertion_sort.sort(self.input)
         self.assertEqual(self.correct, self.output)
 
@@ -108,13 +149,13 @@ class TestQuickSortInPlace(SortingAlgorithmTestCase):
         )
 
 
-class TestHeapSort(SortingAlgorithmTestCase):
+class TestSelectionort(SortingAlgorithmTestCase):
     """
-    Test Heap sort on a small range from 0-9
+    Test Selection sort on a small range from 0-9
     """
 
-    def test_heapsort(self):
-        self.output = heap_sort.sort(self.input)
+    def test_selectionsort(self):
+        self.output = selection_sort.sort(self.input)
         self.assertEqual(self.correct, self.output)
 
 
@@ -125,36 +166,6 @@ class TestShellSort(SortingAlgorithmTestCase):
 
     def test_shellsort(self):
         self.output = shell_sort.sort(self.input)
-        self.assertEqual(self.correct, self.output)
-
-
-class TestCombSort(SortingAlgorithmTestCase):
-    """
-    Test Comb sort on a small range from 0-9
-    """
-
-    def test_combsort(self):
-        self.output = comb_sort.sort(self.input)
-        self.assertEqual(self.correct, self.output)
-
-
-class TestCocktailSort(SortingAlgorithmTestCase):
-    """
-    Tests Cocktail sort on a small range from 0-9
-    """
-
-    def test_cocktailsort(self):
-        self.output = cocktail_sort.sort(self.input)
-        self.assertEqual(self.correct, self.output)
-
-
-class TestGnomeSort(SortingAlgorithmTestCase):
-    """
-    Tests Gnome sort on a small range from 0-9
-    """
-
-    def test_gnomesort(self):
-        self.output = gnome_sort.sort(self.input)
         self.assertEqual(self.correct, self.output)
 
 


### PR DESCRIPTION
* I recently started using this library for practicing implementation of some algorithms and I decided to run some tests. I saw the tests were a little bit un-ordered so it was difficult to keep track. 

* The files in directory are arranged in alphabetical order and so if the tests are too arranged in that way, it is better to analyze the code for a third person viewing it.

* So I have ordered the tests in each file alphabetically, and on the way I discovered that two tests were not written - bogo sort, and primality test. I have added them in too.

* I develop in Pycharm IDE by Jetbrains community, and nowadays many python users do so. This IDE generates a `.idea/` directory which does not need to be on Github, so I also updated the gitignore file in the PR.

* I do not intend to do more work in the PR unless there are issues with the current code written here. So if the checks pass and the reviewer feels it is proper, this PR is fit to be merged. :+1: 