### PR TITLE
Fix spelling errors in documentation

### DIFF
--- a/algorithms/data_structures/binary_search_tree.py
+++ b/algorithms/data_structures/binary_search_tree.py
@@ -3,7 +3,7 @@
     ------------------
     The Binary Search Tree represents an ordered symbol table of generic
     key-value pairs.  Keys must be comparable.  Does not permit duplicate keys.
-    When assocating a value with a key already present in the BST, the previous
+    When associating a value with a key already present in the BST, the previous
     value is replaced by the new one.  This implementation is for an unbalanced
     BST.
 
@@ -385,7 +385,7 @@ class BinarySearchTree(object):
 
     def keys(self):
         """
-        Return all of the keys in the BST in aschending order
+        Return all of the keys in the BST in ascending order
 
         Worst Case Complexity: O(N)
 


### PR DESCRIPTION
This fixes spelling errors in the Binary Search Tree module documented here: 

http://algorithms.readthedocs.io/en/latest/data_structures.html#binary-search-tree